### PR TITLE
Omit package info dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opvious/sdk-ts-packages",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "repository": "github:opvious/sdk.ts",
   "author": "Opvious Engineering <oss@opvious.io>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opvious-cli",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "repository": "github:opvious/sdk.ts",
   "description": "Opvious CLI",
   "homepage": "https://www.opvious.io/sdk.ts/modules/opvious_cli.html",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opvious",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "repository": "github:opvious/sdk.ts",
   "description": "Opvious SDK",
   "homepage": "https://www.opvious.io/sdk.ts/modules/opvious.html",

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -26,7 +26,7 @@ import fetch, {Headers, RequestInfo, RequestInit, Response} from 'node-fetch';
 import {TypedEmitter} from 'tiny-typed-emitter';
 import zlib from 'zlib';
 
-import {MarkPresent, packageInfo, strippingTrailingSlashes} from '../common';
+import {MarkPresent, strippingTrailingSlashes} from '../common';
 import {
   AttemptTracker,
   AttemptTrackerListeners,
@@ -60,7 +60,7 @@ export class OpviousClient {
 
   /** Creates a new client. */
   static create(opts?: OpviousClientOptions): OpviousClient {
-    const tel = (opts?.telemetry ?? noopTelemetry()).via(packageInfo);
+    const tel = opts?.telemetry ?? noopTelemetry();
     const {logger} = tel;
 
     const auth = opts?.authorization ?? process.env.OPVIOUS_TOKEN;
@@ -78,7 +78,6 @@ export class OpviousClient {
       headers: {
         'accept-encoding': 'br;q=1.0, gzip;q=0.5, *;q=0.1',
         authorization: auth.includes(' ') ? auth : 'Bearer ' + auth,
-        'opvious-sdk': 'TypeScript v' + packageInfo.version,
       },
       async fetch(info: RequestInfo, init: RequestInit): Promise<Response> {
         const {body} = init;

--- a/packages/sdk/src/common.ts
+++ b/packages/sdk/src/common.ts
@@ -15,17 +15,8 @@
  * the License.
  */
 
-import {enclosingPackageInfo} from '@opvious/stl-telemetry';
-import * as gql from 'graphql';
 
-export const packageInfo = enclosingPackageInfo(__dirname);
-
-export function assertNoErrors<V>(res: gql.ExecutionResult<V, unknown>): void {
-  if (res.errors?.length) {
-    throw new Error('API call failed: ' + JSON.stringify(res.errors, null, 2));
-  }
-}
-
+/** Returns the input string with any trailing slashes removed. */
 export function strippingTrailingSlashes(arg: string): string {
   return arg.replace(/\/+$/, '');
 }

--- a/packages/sheets/package.json
+++ b/packages/sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opvious-sheets",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "repository": "github:opvious/sdk.ts",
   "description": "Opvious spreadsheet utilities",
   "homepage": "https://www.opvious.io/sdk.ts/modules/opvious_sheets.html",


### PR DESCRIPTION
It causes issues with `ncc` used in https://github.com/opvious/register-specification-action: this package's `package.info` is not available with the distributed code.